### PR TITLE
docs: align workflow documentation with branch-protection ruleset

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -49,18 +49,40 @@ jobs:
 
 Never use `permissions: write-all`.
 
-## Branch protection expectations
+## Branch protection (active ruleset)
 
-`CODEOWNERS` and the `sync-check` / `safety-scan` jobs are only meaningful when branch protection on `main` enforces them. The expected settings:
+`main` is protected by a GitHub ruleset named `main protection`. The ruleset is the active enforcement mechanism; the settings listed here are the canonical record because ruleset configuration lives in repo settings, not in git history.
 
-- Require a pull request before merging.
-- Require review from Code Owners.
-- Require status checks to pass: `validate-registry`, `validate-docs`, `validate-scaffold`, `sync-check`, `safety-scan`.
-- Require signed commits (DCO App verifies `Signed-off-by:` on every commit).
-- Disallow force pushes to `main`.
-- Disallow deletion of `main`.
+Current rules:
 
-These settings are not code; they must be configured in the repository settings. A maintainer change to branch protection does not show up in git history, so this file is the canonical record.
+| Rule | Configuration |
+|------|---------------|
+| Target | `~DEFAULT_BRANCH` (main) |
+| Enforcement | Active |
+| Bypass actors | None (applies to every contributor including the repo owner) |
+| Pull request required | 0 approving reviews, squash-merge only, other merge methods blocked |
+| Force pushes | Blocked (`non_fast_forward` rule) |
+| Branch deletion | Blocked (`deletion` rule) |
+
+Required status checks (a PR cannot merge until all 8 pass):
+
+- `Validate registry.json`
+- `Validate docs site`
+- `Validate scaffold`
+- `Registry sync check`
+- `Public-repo safety scan`
+- `feat/fix commits require VERSION bump`
+- `Check VERSION vs latest tag`
+- `CodeQL`
+
+DCO sign-off enforcement runs via the GitHub DCO App as a separate status check; it is not in the ruleset's required-checks list but PRs with unsigned commits are blocked by the App regardless.
+
+Verify current state:
+
+```bash
+gh api repos/TMHSDigital/Developer-Tools-Directory/rulesets
+gh api repos/TMHSDigital/Developer-Tools-Directory/rulesets/<id>
+```
 
 ## Forbidden patterns
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -64,7 +64,7 @@ Current rules:
 | Force pushes | Blocked (`non_fast_forward` rule) |
 | Branch deletion | Blocked (`deletion` rule) |
 
-Required status checks (a PR cannot merge until all 8 pass):
+Required status checks (a PR cannot merge until all 7 pass):
 
 - `Validate registry.json`
 - `Validate docs site`
@@ -72,8 +72,9 @@ Required status checks (a PR cannot merge until all 8 pass):
 - `Registry sync check`
 - `Public-repo safety scan`
 - `feat/fix commits require VERSION bump`
-- `Check VERSION vs latest tag`
 - `CodeQL`
+
+Post-merge guard (not in required-contexts): `release.yml`'s `Check VERSION vs latest tag` job runs on every push to `main` and fails the release if `VERSION` is behind the latest tag. It is intentionally excluded from the PR-required list because it cannot run on a PR (`release.yml` only triggers on push), and including it would permanently block every PR.
 
 DCO sign-off enforcement runs via the GitHub DCO App as a separate status check; it is not in the ruleset's required-checks list but PRs with unsigned commits are blocked by the App regardless.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,12 +20,28 @@ This is a **meta-repository** -- it does not contain a Cursor plugin or MCP serv
 ## Branching and commit model
 
 - **Single branch**: `main` only. No develop/release branches.
+- **All changes land via pull request.** `main` is protected by an active ruleset (`main protection`) that blocks direct pushes, force pushes, and branch deletion for every contributor including the repo owner. No bypass actors are configured.
+- **Squash merge only.** Other merge methods are blocked by the ruleset.
+- **Zero required approvals** (solo-maintainer repo), but all required status checks must pass before a PR can be merged.
 - **Conventional commits** are required:
   - `feat:` -- new tool added to registry, new standard doc, new scaffold template
   - `fix:` -- corrections to existing content
   - `chore:` -- dependency updates, CI changes
   - `docs:` -- documentation-only changes
 - Commit messages should be concise and describe the "why", not the "what".
+
+### Required status checks (ruleset-enforced on `main`)
+
+Every PR must pass these 8 checks before it can be merged:
+
+- `Validate registry.json`
+- `Validate docs site`
+- `Validate scaffold`
+- `Registry sync check`
+- `Public-repo safety scan`
+- `feat/fix commits require VERSION bump`
+- `Check VERSION vs latest tag`
+- `CodeQL`
 
 ## CI/CD workflows
 
@@ -244,17 +260,25 @@ Pure documentation -- no code. Each file documents a convention derived from ana
 - Conventional commits are required (`feat:`, `fix:`, `chore:`, `docs:`), with a `Signed-off-by:` trailer (DCO; see [`CONTRIBUTING.md`](CONTRIBUTING.md)).
 - Single branch: `main` only.
 
-## Branch protection (maintainer responsibility)
+## Branch protection (active)
 
-The `main` branch on this repo should be protected with:
+`main` is protected by a GitHub ruleset named `main protection`. Current configuration:
 
-- Require pull request reviews before merging
-- Require status checks to pass: `validate-registry`, `sync-check`, `safety-scan`, DCO
-- Require signed commits (enforced by the DCO App)
-- Disallow force pushes
-- Disallow deletions
+- **Enforcement:** active, target is the default branch, bypass actors list is empty (applies to the repo owner as well).
+- **Pull request required:** 0 approving reviews, squash-merge only, other merge methods blocked.
+- **Required status checks:** `Validate registry.json`, `Validate docs site`, `Validate scaffold`, `Registry sync check`, `Public-repo safety scan`, `feat/fix commits require VERSION bump`, `Check VERSION vs latest tag`, `CodeQL`.
+- **Force pushes blocked** (`non_fast_forward` rule).
+- **Branch deletion blocked** (`deletion` rule).
+- **Signed commits** are enforced at commit-sign-off level by the DCO App status check (separate from the ruleset).
 
-These settings live outside the repo (Settings > Branches). They are not stored as code and must be configured manually by a maintainer with admin access.
+Agents must branch, push, and open a PR even for single-file edits. Direct pushes to `main` will be rejected by the ruleset.
+
+Ruleset configuration lives in repo settings, not in git history. Verify the current state with:
+
+```
+gh api repos/TMHSDigital/Developer-Tools-Directory/rulesets
+gh api repos/TMHSDigital/Developer-Tools-Directory/rulesets/<id>
+```
 
 ## Dependencies
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ This is a **meta-repository** -- it does not contain a Cursor plugin or MCP serv
 
 ### Required status checks (ruleset-enforced on `main`)
 
-Every PR must pass these 8 checks before it can be merged:
+Every PR must pass these 7 checks before it can be merged:
 
 - `Validate registry.json`
 - `Validate docs site`
@@ -40,8 +40,9 @@ Every PR must pass these 8 checks before it can be merged:
 - `Registry sync check`
 - `Public-repo safety scan`
 - `feat/fix commits require VERSION bump`
-- `Check VERSION vs latest tag`
 - `CodeQL`
+
+`release.yml`'s `Check VERSION vs latest tag` is a post-merge guard that only runs on push to `main`, so it is deliberately not in the required-contexts list (including it would permanently block every PR).
 
 ## CI/CD workflows
 
@@ -266,7 +267,7 @@ Pure documentation -- no code. Each file documents a convention derived from ana
 
 - **Enforcement:** active, target is the default branch, bypass actors list is empty (applies to the repo owner as well).
 - **Pull request required:** 0 approving reviews, squash-merge only, other merge methods blocked.
-- **Required status checks:** `Validate registry.json`, `Validate docs site`, `Validate scaffold`, `Registry sync check`, `Public-repo safety scan`, `feat/fix commits require VERSION bump`, `Check VERSION vs latest tag`, `CodeQL`.
+- **Required status checks:** `Validate registry.json`, `Validate docs site`, `Validate scaffold`, `Registry sync check`, `Public-repo safety scan`, `feat/fix commits require VERSION bump`, `CodeQL`.
 - **Force pushes blocked** (`non_fast_forward` rule).
 - **Branch deletion blocked** (`deletion` rule).
 - **Signed commits** are enforced at commit-sign-off level by the DCO App status check (separate from the ruleset).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,25 @@ Static HTML/CSS/JS. No build step. No external CDN. The `pages.yml` workflow cop
 
 ## Development Workflow
 
+### Contribution flow
+
+`main` is protected by the `main protection` ruleset. Direct pushes, force pushes, and branch deletion are all blocked for every contributor including the repo owner (empty bypass list). All changes land via pull request with squash merge only.
+
+Standard loop for any change, including single-file edits:
+
+```bash
+git checkout -b <type>/<short-description>
+# edits
+git add <paths>
+git commit -s -m "<conventional subject>"
+git push -u origin HEAD
+gh pr create --base main
+gh pr checks <number> --watch
+gh pr merge <number> --squash --delete-branch
+```
+
+A PR cannot be merged until all 8 required status checks pass: `Validate registry.json`, `Validate docs site`, `Validate scaffold`, `Registry sync check`, `Public-repo safety scan`, `feat/fix commits require VERSION bump`, `Check VERSION vs latest tag`, `CodeQL`. Required approvals are 0 (solo maintainer).
+
 ### Prerequisites
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ gh pr checks <number> --watch
 gh pr merge <number> --squash --delete-branch
 ```
 
-A PR cannot be merged until all 8 required status checks pass: `Validate registry.json`, `Validate docs site`, `Validate scaffold`, `Registry sync check`, `Public-repo safety scan`, `feat/fix commits require VERSION bump`, `Check VERSION vs latest tag`, `CodeQL`. Required approvals are 0 (solo maintainer).
+A PR cannot be merged until all 7 required status checks pass: `Validate registry.json`, `Validate docs site`, `Validate scaffold`, `Registry sync check`, `Public-repo safety scan`, `feat/fix commits require VERSION bump`, `CodeQL`. Required approvals are 0 (solo maintainer). `release.yml`'s `Check VERSION vs latest tag` is a post-merge guard, not a PR gate.
 
 ### Prerequisites
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,6 +228,14 @@ Where `$TOOLS_ROOT` is the parent directory containing your checkouts of each to
 
 ## Pull Request Process
 
+### Branch protection
+
+`main` is protected by an active ruleset (`main protection`). All contributions, including from the repo owner, must land through a pull request. Direct pushes, force pushes, and branch deletion are blocked. The bypass-actors list is empty.
+
+- Required approvals: 0 (solo-maintainer repo).
+- Merge method: squash merge only; merge commits and rebase merges are blocked.
+- All 8 required status checks listed under [CI checks](#ci-checks) must pass before merge is allowed.
+
 ### Branch naming
 
 Use descriptive branch names with a type prefix:
@@ -254,7 +262,7 @@ The meta-repo uses a `VERSION` file at the repo root as the single source of tru
 Rules:
 
 - `VERSION` contains a single semver line, no `v` prefix, LF line ending (`1.6.1`).
-- Any commit whose subject starts with `feat:` or `fix:` (including scoped variants like `feat(registry):`) requires a `VERSION` bump in the same PR. The `version-bump-check` CI job enforces this.
+- Any commit whose subject starts with `feat:` or `fix:` (including scoped variants like `feat(registry):`) requires a `VERSION` bump in the same PR. The `version-bump-check` CI job enforces this, and it is a required status check in the branch-protection ruleset, so a PR without the bump cannot be merged.
 - `chore:`, `docs:`, `ci:`, `refactor:`, `test:`, and `style:` commits do not require a bump.
 - Bump kind is at your discretion and guided by semver: breaking behavior change to a published contract is major, new capability is minor, correction with no behavior change is patch.
 - Escape hatch: add `[skip version]` to the commit subject or body for workflow-only changes that slipped into a `feat:`/`fix:` subject. Use sparingly.
@@ -279,12 +287,18 @@ Before submitting a PR, verify:
 
 ### CI checks
 
-All PRs must pass:
-- Registry schema validation
-- Docs file existence
-- Scaffold syntax and dry-run test
-- CodeQL security scan
-- Dependency review
+All PRs must pass these 8 required status checks (enforced by the `main protection` ruleset, not just advisory):
+
+- `Validate registry.json` - JSON schema and required fields
+- `Validate docs site` - `docs/index.html`, `style.css`, `script.js` exist
+- `Validate scaffold` - Python syntax and scaffold dry-run
+- `Registry sync check` - `scripts/sync_from_registry.py --check` exits 0
+- `Public-repo safety scan` - no leaked emails, drive paths, unsafe DOM sinks, or committed secrets
+- `feat/fix commits require VERSION bump` - enforces the rule in the Versioning section
+- `Check VERSION vs latest tag` - ensures `VERSION` is not behind the latest tag
+- `CodeQL` - security scan on Python code
+
+Additional (non-required) checks run on most PRs: dependency review, release-drafter preview, Socket Security. These provide signal but do not gate merges.
 
 ## Style Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,7 +234,7 @@ Where `$TOOLS_ROOT` is the parent directory containing your checkouts of each to
 
 - Required approvals: 0 (solo-maintainer repo).
 - Merge method: squash merge only; merge commits and rebase merges are blocked.
-- All 8 required status checks listed under [CI checks](#ci-checks) must pass before merge is allowed.
+- All 7 required status checks listed under [CI checks](#ci-checks) must pass before merge is allowed.
 
 ### Branch naming
 
@@ -287,7 +287,7 @@ Before submitting a PR, verify:
 
 ### CI checks
 
-All PRs must pass these 8 required status checks (enforced by the `main protection` ruleset, not just advisory):
+All PRs must pass these 7 required status checks (enforced by the `main protection` ruleset, not just advisory):
 
 - `Validate registry.json` - JSON schema and required fields
 - `Validate docs site` - `docs/index.html`, `style.css`, `script.js` exist
@@ -295,8 +295,9 @@ All PRs must pass these 8 required status checks (enforced by the `main protecti
 - `Registry sync check` - `scripts/sync_from_registry.py --check` exits 0
 - `Public-repo safety scan` - no leaked emails, drive paths, unsafe DOM sinks, or committed secrets
 - `feat/fix commits require VERSION bump` - enforces the rule in the Versioning section
-- `Check VERSION vs latest tag` - ensures `VERSION` is not behind the latest tag
 - `CodeQL` - security scan on Python code
+
+`release.yml`'s `Check VERSION vs latest tag` runs on every push to `main` and will fail the release if `VERSION` is behind the latest tag. It is a post-merge guard, not a PR gate, so it is not in the required-contexts list.
 
 Additional (non-required) checks run on most PRs: dependency review, release-drafter preview, Socket Security. These provide signal but do not gate merges.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,10 +4,11 @@
 
 ## Current Status
 
-**v1.6.2** - Patch release. Release-drafter no longer computes its own version; change-note aggregation only. Versioning is fully driven by the `VERSION` file and `release.yml`.
+**v1.6.3** - Patch release. Resolves drafter-body detection and branch-protection residuals from the version-scheme migration. `release.yml` now treats a drafter body of `## What's Changed / * No changes` as empty and falls through to the commit-log fallback. `main` is now protected by a GitHub ruleset (`main protection`) with 8 required status checks including `feat/fix commits require VERSION bump`, squash-merge only, no force pushes, no deletion, empty bypass list. Documentation across AGENTS.md, CLAUDE.md, CONTRIBUTING.md, `.github/workflows/README.md`, and `standards/ci-cd.md` updated to reflect the PR-based workflow.
 
 Prior milestones in this line:
 
+- **v1.6.2** - Release-drafter decoupling. Release-drafter no longer computes its own version; change-note aggregation only. Versioning is fully driven by the `VERSION` file and `release.yml`.
 - **v1.6.1** - `VERSION`-file-driven releases. Replaces conventional-commit auto-bump with an authoritative `VERSION` file; `feat:`/`fix:` commits require a VERSION bump enforced by CI.
 - **v1.6.0** - Standards and Governance. Nine new standards docs, registry-to-artifact sync automation, DCO + inbound license grant, scope and lifecycle principles, public-repo safety hardening.
 
@@ -24,6 +25,7 @@ Prior milestones in this line:
 | v1.6.0 | Standards and Governance | Released |
 | v1.6.1 | VERSION-file-driven releases | Released |
 | v1.6.2 | Release-drafter decoupling | Released |
+| v1.6.3 | Drafter-body fix and branch-protection ruleset | Released |
 | v1.7.0 | Sync Everywhere and Agent-File Drift | Planned |
 | v1.8.0 | Observability and Feedback | Planned |
 | v1.9.0 | Standards Versioning | Planned |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@
 
 ## Current Status
 
-**v1.6.3** - Patch release. Resolves drafter-body detection and branch-protection residuals from the version-scheme migration. `release.yml` now treats a drafter body of `## What's Changed / * No changes` as empty and falls through to the commit-log fallback. `main` is now protected by a GitHub ruleset (`main protection`) with 8 required status checks including `feat/fix commits require VERSION bump`, squash-merge only, no force pushes, no deletion, empty bypass list. Documentation across AGENTS.md, CLAUDE.md, CONTRIBUTING.md, `.github/workflows/README.md`, and `standards/ci-cd.md` updated to reflect the PR-based workflow.
+**v1.6.3** - Patch release. Resolves drafter-body detection and branch-protection residuals from the version-scheme migration. `release.yml` now treats a drafter body of `## What's Changed / * No changes` as empty and falls through to the commit-log fallback. `main` is now protected by a GitHub ruleset (`main protection`) with 7 required status checks including `feat/fix commits require VERSION bump`, squash-merge only, no force pushes, no deletion, empty bypass list. Documentation across AGENTS.md, CLAUDE.md, CONTRIBUTING.md, `.github/workflows/README.md`, and `standards/ci-cd.md` updated to reflect the PR-based workflow.
 
 Prior milestones in this line:
 

--- a/standards/ci-cd.md
+++ b/standards/ci-cd.md
@@ -149,8 +149,9 @@ Every repo must protect `main` with a GitHub ruleset or classic branch protectio
 
 Repos using the meta-repo's `VERSION`-file-driven release model additionally require:
 
-- `Check VERSION vs latest tag`
-- `feat/fix commits require VERSION bump`
+- `feat/fix commits require VERSION bump` (PR gate, runs in `validate.yml`)
+
+The companion `Check VERSION vs latest tag` job in `release.yml` is a post-merge guard that runs on push to `main`. It should NOT be added to the PR-required-contexts list; doing so will permanently block every PR because `release.yml` does not run on PRs.
 
 Required approvals are a per-repo decision: solo-maintainer repos may set 0 approvals provided all other gates pass; multi-maintainer repos should require at least 1.
 

--- a/standards/ci-cd.md
+++ b/standards/ci-cd.md
@@ -126,3 +126,34 @@ Marks issues and PRs as stale after inactivity and closes them after further ina
 - Use `${{ secrets.GITHUB_TOKEN }}` (automatically provided) for all Git operations
 - Never store custom secrets unless absolutely required (e.g., npm publish tokens)
 - Set minimal `permissions` at the workflow level, not at the job level
+
+## Branch Protection and Merge Policy
+
+Every repo must protect `main` with a GitHub ruleset or classic branch protection that enforces the following. The meta-repo's `main protection` ruleset is the reference implementation.
+
+**Required rules:**
+
+- Direct pushes to `main` blocked; all changes land via pull request.
+- Force pushes blocked (`non_fast_forward`).
+- Branch deletion blocked.
+- Empty bypass-actors list (policy applies to repo owner and admins).
+- Squash-merge only. Merge commits and rebase merges should be disabled.
+
+**Required status checks** (minimum for plugin/tool repos):
+
+- JSON/manifest validation job
+- Skill and rule file-existence job
+- Credential-scanning / safety-scan job
+- `CodeQL` (if the repo includes source code substantive enough to scan)
+- Any repo-specific sync-check or safety-scan jobs
+
+Repos using the meta-repo's `VERSION`-file-driven release model additionally require:
+
+- `Check VERSION vs latest tag`
+- `feat/fix commits require VERSION bump`
+
+Required approvals are a per-repo decision: solo-maintainer repos may set 0 approvals provided all other gates pass; multi-maintainer repos should require at least 1.
+
+**Configuration lives in repo settings, not in git.** Document the current ruleset in `.github/workflows/README.md` so the state is discoverable without admin access.
+
+> Note: the tool-repo release model described in `release.yml` above uses conventional-commit auto-bumps and does not currently require the `VERSION`/`version-bump-check` gates. The meta-repo deviates intentionally. A decision on whether to propagate the `VERSION`-file model to tool repos is deferred; see `ROADMAP.md`.


### PR DESCRIPTION
Updates workflow documentation across AGENTS.md, CLAUDE.md, CONTRIBUTING.md, .github/workflows/README.md, standards/ci-cd.md, and ROADMAP.md to reflect the new branch-protection ruleset on main. Closes out the version-scheme migration by documenting the enforced workflow.

Scope is documentation only. No code, workflow, or config changes. Also notes v1.6.3 resolved residuals 1 and 3 from the migration.

Left for future sessions: propagating the new ci-cd standard to the 9 tool repos (belongs in v1.7 drift-checker work); updating scaffold templates if needed (deliberate scaffold session).

Made with [Cursor](https://cursor.com)