### PR TITLE
chore: finish Phase 1 with standards template and scaffold updates

### DIFF
--- a/scaffold/create-tool.py
+++ b/scaffold/create-tool.py
@@ -20,6 +20,7 @@ except ImportError:
 
 
 TEMPLATES_DIR = Path(__file__).parent / "templates"
+VERSION_FILE = Path(__file__).parent.parent / "VERSION"
 
 LICENSE_FILES = {
     "cc-by-nc-nd-4.0": "CC-BY-NC-ND-4.0",
@@ -38,6 +39,34 @@ def slugify(name: str) -> str:
     slug = name.lower().strip()
     slug = re.sub(r"[^a-z0-9]+", "-", slug)
     return slug.strip("-")
+
+
+def read_standards_version() -> str:
+    """Read the meta-repo VERSION at generation time.
+
+    New tool repos are pre-aligned with the current standards version, so the
+    value here is not a runtime decision. If VERSION is missing or unreadable,
+    fail loudly rather than silently substituting a default - a wrong version
+    would defeat the drift-checker invariant.
+    """
+    try:
+        raw = VERSION_FILE.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        print(
+            f"Error: VERSION file not found at {VERSION_FILE}. "
+            "The scaffold must run from a working copy of Developer-Tools-Directory."
+        )
+        sys.exit(1)
+    except OSError as e:
+        print(f"Error: could not read {VERSION_FILE}: {e}")
+        sys.exit(1)
+    if not re.fullmatch(r"\d+\.\d+\.\d+", raw):
+        print(
+            f"Error: VERSION contents '{raw}' are not a valid X.Y.Z semver string. "
+            "Refusing to emit a standards-version marker with a malformed value."
+        )
+        sys.exit(1)
+    return raw
 
 
 def parse_args():
@@ -122,6 +151,8 @@ def main():
     skill_names = [f"skill-{i + 1}" for i in range(args.skills)]
     rule_names = [f"rule-{i + 1}" for i in range(args.rules)]
 
+    standards_version = read_standards_version()
+
     ctx = {
         "name": args.name,
         "slug": slug,
@@ -138,6 +169,7 @@ def main():
         "author_email": args.author_email,
         "repo_owner": "TMHSDigital",
         "repo_name": slug,
+        "standards_version": standards_version,
     }
 
     print(f"\nScaffolding '{args.name}' ({slug}) into {output_dir}\n")
@@ -183,6 +215,7 @@ name: {skill}
 description: TODO - describe this skill
 globs: ["**/*"]
 alwaysApply: false
+standards-version: {standards_version}
 ---
 
 # {skill.replace('-', ' ').title()}
@@ -197,6 +230,7 @@ TODO: Add skill content here.
 description: TODO - describe this rule
 globs: ["**/*"]
 alwaysApply: false
+standards-version: {standards_version}
 ---
 
 # {rule.replace('-', ' ').title()}

--- a/scaffold/templates/AGENTS.md.j2
+++ b/scaffold/templates/AGENTS.md.j2
@@ -1,3 +1,5 @@
+<!-- standards-version: {{ standards_version }} -->
+
 # AGENTS.md
 
 This file tells AI coding agents how the {{ name }} repo works and how to contribute correctly.

--- a/scaffold/templates/CLAUDE.md.j2
+++ b/scaffold/templates/CLAUDE.md.j2
@@ -1,3 +1,5 @@
+<!-- standards-version: {{ standards_version }} -->
+
 # CLAUDE.md
 
 This file provides guidance for Claude Code when working in this repository.

--- a/standards/agents-template.md
+++ b/standards/agents-template.md
@@ -6,7 +6,11 @@ Every developer tool repo must include an `AGENTS.md` file at the root. This fil
 
 ### 1. Header
 
+Every `AGENTS.md` and `CLAUDE.md` in a tool repo must start with a `standards-version` marker on the first line, followed by a blank line, followed by the H1 title. The marker is an HTML comment so it does not render in GitHub's Markdown viewer.
+
 ```markdown
+<!-- standards-version: X.Y.Z -->
+
 # AGENTS.md
 
 This file tells AI coding agents how the <Tool Name> repo works
@@ -14,6 +18,12 @@ and how to contribute correctly.
 
 **Documentation site:** <URL> (auto-deployed on push to main)
 ```
+
+`X.Y.Z` matches the `Developer-Tools-Directory` `VERSION` the tool repo is aligned with. Update it when the tool repo is re-aligned with a new meta-repo release; do not update it on every commit.
+
+**Rationale:** the HTML comment format preserves the pure-Markdown, prose-first convention of `AGENTS.md` and `CLAUDE.md` (no YAML frontmatter in files that render as rendered docs), while giving the drift checker in `Developer-Tools-Directory` a deterministic signal to detect which version of the ecosystem standards a tool repo was last aligned with.
+
+`SKILL.md` and `.mdc` rule files use a different mechanism: a YAML frontmatter field named `standards-version`, placed alongside `name`, `description`, `globs`, `alwaysApply`. Those files are metadata-first component files rather than prose documents, so frontmatter is the natural home for the signal. See `standards/skills.md` and `standards/rules.md` for the full frontmatter conventions.
 
 ### 2. Repository Overview
 


### PR DESCRIPTION
Closes the final two Phase 1 checkboxes on Issue #1. Updates standards/agents-template.md to document the HTML comment marker. Updates scaffold/create-tool.py to pre-populate standards-version on generated AGENTS.md, CLAUDE.md, SKILL.md, and .mdc files. Reads current version from the VERSION file at generation time.

Made with [Cursor](https://cursor.com)