### PR TITLE
TEST: verify version-bump-check enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,3 +222,6 @@ Pull requests welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, how-to 
 <p align="center">
  <strong>Built by <a href="https://github.com/TMHSDigital">TMHSDigital</a></strong>
 </p>
+
+<!-- Test for version-bump-check (delete this line; PR will be closed) -->
+


### PR DESCRIPTION
Verifying that version-bump-check actually fails on feat: PRs without a VERSION bump after the DTD#24 fix in PR #28. CLOSE WITHOUT MERGING after verifying the check fails red.

Made with [Cursor](https://cursor.com)