### PR TITLE
chore: add github-actions ecosystem to dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Closes #31. Adds dependabot coverage for the github-actions ecosystem in the meta-repo. Especially relevant since this repo ships the drift checker that audits consumers but did not audit its own action versions until now.

Made with [Cursor](https://cursor.com)