### PR TITLE
chore: add Sponsor button and FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [TMHSDigital]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
  <a href="https://github.com/TMHSDigital/Developer-Tools-Directory/actions/workflows/codeql.yml"><img src="https://github.com/TMHSDigital/Developer-Tools-Directory/actions/workflows/codeql.yml/badge.svg" alt="CodeQL" /></a>
  <a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.12+-3776ab?logo=python&logoColor=white" alt="Python 3.12+" /></a>
  <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen" alt="PRs Welcome" /></a>
+ <a href="https://github.com/sponsors/TMHSDigital"><img src="https://img.shields.io/badge/sponsor-%E2%9D%A4-EA4AAA?logo=githubsponsors&logoColor=white" alt="Sponsor" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Adds the GitHub Sponsors button to the repo header (via .github/FUNDING.yml) and a matching shield in the README badge row.

Defaults to GitHub Sponsors with the org handle `TMHSDigital`. To add Buy Me a Coffee, Ko-fi, Open Collective, Patreon, or a custom URL, extend .github/FUNDING.yml per [GitHub's docs](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository).

Note: the Sponsor button only renders on github.com if GitHub Sponsors is enabled for the TMHSDigital org/account. If not yet enabled, FUNDING.yml is harmless (the README shield links work either way and will redirect to the sponsors page once enabled).