### PR TITLE
docs: update release-doc-sync header comment to reflect actual @v1 / @v1.X convention

### DIFF
--- a/.github/actions/release-doc-sync/action.yml
+++ b/.github/actions/release-doc-sync/action.yml
@@ -27,11 +27,19 @@
 #      list as outputs so the caller can branch on them or include them in
 #      the release commit message.
 #
-# Pinning rule: tool repos MUST consume this action via @v1.0 (or a SHA),
-# never @main. The meta-repo's tag pipeline maintains the v1.0 tag pointing
-# at the latest 1.x.y. See DTD#14 for the floating-tag automation
-# follow-up. The drift-check@v1.7 lessons apply: @main from a tool repo
-# means every meta-repo PR can break every tool-repo release.
+# Pinning rule: tool repos MUST consume this action via a floating tag or a
+# SHA, never @main. Three supported pin styles:
+#   - @v1     (floating major, default; auto-maintained by release.yml on
+#             every release; what most consumers use)
+#   - @v1.X   (floating minor, e.g. @v1.9; auto-maintained; used by strict
+#             consumers that want minor-level pinning while still picking up
+#             patch updates automatically)
+#   - @<SHA>  (full commit SHA; strictest, manual maintenance; used only when
+#             a consumer needs to freeze the action at a specific point)
+# The meta-repo's tag pipeline maintains @v1 and the @v1.X floating tags on
+# every release. See DTD#14 for the floating-tag automation status. The
+# drift-check@v1.7 lessons apply: @main from a tool repo means every
+# meta-repo PR can break every tool-repo release.
 # =============================================================================
 
 name: 'Release doc sync'


### PR DESCRIPTION
Updates release-doc-sync action header comment to reflect the actual current pin convention.

## Previous text

Referenced `@v1.0` as the canonical pin and described the meta-repo as maintaining "the v1.0 tag pointing at the latest 1.x.y". The `v1.0` tag was never actually created. DTD#42 fixed the runtime default of the `meta-repo-ref` input (changed from `v1.0` to `v1`) but the header comment was deliberately left untouched in that change to keep the diff scoped.

## New text

Describes the three supported pin styles:

- `@v1`     - floating major, default; auto-maintained by `release.yml` on every release; what most consumers use
- `@v1.X`   - floating minor (e.g. `@v1.9`); auto-maintained; for consumers that want minor-level pinning while still picking up patch updates
- `@<SHA>`  - full commit SHA; strictest, manual maintenance; for consumers that need to freeze the action at a specific point

## Scope

Single header comment edit, no runtime behavior change. `docs:` prefix means no VERSION bump and no auto-release fires (correct for a doc-only fix; the runtime default and tags are unchanged).

Closes #44.
