### PR TITLE
chore: broaden scaffold test output gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,5 @@ Thumbs.db
 
 # Scaffold test output
 output/
+_scaffold*/
 /tmp/


### PR DESCRIPTION
## Summary

- Adds `_scaffold*/` glob to `.gitignore` under the existing scaffold test output block
- The previous `output/` entry did not match `_scaffold_output/`, which is the directory name produced by local scaffold test runs
- The glob covers `_scaffold_output/` and any future underscore-prefixed variants without needing explicit entries

Verified that no tracked path matches `_scaffold*/` -- all tracked scaffold paths live under `scaffold/` (no leading underscore).

## Test plan

- [ ] Confirm `_scaffold_output/` no longer appears in `git status` after merge
- [ ] Confirm `git ls-files | grep _scaffold` returns nothing (no tracked paths accidentally shadowed)
- [ ] CI: no VERSION bump required (chore prefix)