### PR TITLE
chore: ignore Windows NUL device artifact in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ Thumbs.db
 output/
 _scaffold*/
 /tmp/
+
+# Windows NULL device - appears as untracked on Windows when shells redirect to nul
+nul


### PR DESCRIPTION
## Summary

- Adds `nul` to `.gitignore` so the Windows NULL device no longer appears as an untracked file in `git status`
- `nul` is a Windows reserved device name (equivalent to `/dev/null`); it cannot be created or deleted as a real file, but git on Windows detects it as an untracked entry when a shell has redirected to it
- No committed files affected

## Checklist

- [x] No em dashes, en dashes, or emoji
- [x] DCO sign-off on commit
- [x] Only .gitignore edited