### PR TITLE
fix(scaffold): mcp-server docs match tag-only release; npm dependabot with held majors

### DIFF
--- a/scaffold/templates/AGENTS.md.j2
+++ b/scaffold/templates/AGENTS.md.j2
@@ -32,10 +32,17 @@ This is an MCP server. It contains:
 ## Branching and commit model
 
 - **Single branch**: `main` only. No develop/release branches.
+{% if type == 'cursor-plugin' %}
 - **Conventional commits** are required. The release workflow parses them:
   - `feat:` or `feat(scope):` -- triggers a **minor** version bump
   - `feat!:` or `BREAKING CHANGE` -- triggers a **major** version bump
   - Everything else (`fix:`, `chore:`, `docs:`, etc.) -- triggers a **patch** bump
+{% else %}
+- **Conventional commits** are required. Use them to decide your version bump, then apply it in your PR (`npm version <patch|minor|major> --no-git-tag-version`); `release.yml` tags and publishes that version on merge, and CI never writes to `main`:
+  - `feat:` or `feat(scope):` -- bump the **minor** version
+  - `feat!:` or a `BREAKING CHANGE` trailer -- bump the **major** version
+  - everything else (`fix:`, `chore:`, `docs:`, etc.) -- bump the **patch** version
+{% endif %}
 - Commit messages should be concise and describe the "why", not the "what".
 
 ## CI/CD workflows
@@ -121,7 +128,7 @@ Keeps repository labels in sync.
 - Rules use `.mdc` extension with frontmatter.
 {% else %}
 - No hardcoded credentials -- CI scans for password/token/api_key patterns.
-- Conventional commits; never hand-edit the version.
+- Conventional commits; bump the version deliberately in your PR (CI tags and publishes it).
 - Keep `mcp-tools.json` in sync with the tools registered in `src/tools/`.
 {% endif %}
 

--- a/scaffold/templates/CONTRIBUTING.md.j2
+++ b/scaffold/templates/CONTRIBUTING.md.j2
@@ -57,7 +57,7 @@ Use [Conventional Commits](https://www.conventionalcommits.org/):
 - Add it to `mcp-tools.json`
 - Add vitest tests
 
-Never hand-edit the version; CI auto-bumps `package.json`.
+Bump the version in `package.json` in your PR (e.g. `npm version <patch|minor|major> --no-git-tag-version`); CI tags and publishes it on merge.
 
 ## Pull Request Process
 

--- a/scaffold/templates/cursorrules.j2
+++ b/scaffold/templates/cursorrules.j2
@@ -26,7 +26,7 @@ This is a {{ type }} repository for {{ name | replace(' Developer Tools', '') | 
 - Rules need frontmatter: description, globs, alwaysApply
 {% else %}
 - Use conventional commits (feat:, fix:, chore:, docs:)
-- Never manually edit the version -- CI auto-bumps package.json
+- Bump the version in package.json in your PR; CI tags and publishes it
 - Keep mcp-tools.json in sync with the registered tools
 - Provider adapters live in src/providers/; tools live in src/tools/
 {% endif %}

--- a/scaffold/templates/dependabot.yml.j2
+++ b/scaffold/templates/dependabot.yml.j2
@@ -4,6 +4,25 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+{% if type == 'mcp-server' %}
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # zod 3 -> 4 is a deliberate, manual upgrade: the MCP SDK turns these
+      # schemas into each tool's inputSchema JSON, so a major bump can change
+      # the emitted schema without failing the test suite.
+      - dependency-name: "zod"
+        update-types: ["version-update:semver-major"]
+      # Hold the TypeScript 5.x line; 6.x is a transitional major.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      # engines is >=20 and CI runs Node 20/22; do not pull @types/node ahead
+      # of the supported runtimes.
+      - dependency-name: "@types/node"
+        versions: [">=23"]
+{% endif %}
 {% if has_mcp %}
   - package-ecosystem: "pip"
     directory: "/mcp-server"


### PR DESCRIPTION
Stops future mcp-server borns from inheriting the abandoned auto-bump doc language and from shipping without an npm dependabot config (found while cleaning up local-ai-mcp).

- AGENTS.md.j2 (branching + code-conventions), CONTRIBUTING.md.j2, cursorrules.j2 mcp-server branches: auto-bump/never-edit -> bump-in-PR/CI-tags-and-publishes. cursor-plugin branches unchanged (release-doc-sync still auto-bumps).
- dependabot.yml.j2: mcp-server gets an npm ecosystem with held-major ignores baked in (zod major, typescript major, @types/node >=23). cursor-plugin keeps github-actions + (has_mcp) pip.

Verified: pytest 238 passed/1 skipped; mcp render has zero auto-bump phrasing + npm dependabot with the 3 ignores; cursor-plugin render unchanged. The mcp-server template emits no src/, so there is no server-version literal to template. No STANDARDS_VERSION/VERSION change ([skip version]).