### PR TITLE
fix(.gitignore): add site-audit files to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,17 @@ _scaffold*/
 
 # Windows NULL device - appears as untracked on Windows when shells redirect to nul
 nul
+site-audit.md
+site-audit-evidence/cat-dark-390.png
+site-audit-evidence/cat-dark-1280.png
+site-audit-evidence/cat-dark-1920.png
+site-audit-evidence/cat-light-1280.png
+site-audit-evidence/pr1-catalog.png
+site-audit-evidence/pr2-catalog-top.png
+site-audit-evidence/pr3-screencast-mcp-site.png
+site-audit-evidence/pr4-cat-dark.png
+site-audit-evidence/pr4-cat-light.png
+site-audit-evidence/pr4-sc-light.png
+site-audit-evidence/sc-dark-390.png
+site-audit-evidence/sc-dark-1280.png
+site-audit-evidence/sc-light-1280.png


### PR DESCRIPTION
Adds site-audit working files (site-audit.md, site-audit-evidence/) to .gitignore so local audit artifacts are not committed.

Made with [Cursor](https://cursor.com)